### PR TITLE
Feat/#1 실시간 재고 관리 서비스 구현

### DIFF
--- a/src/main/java/com/nayoon/stock_service/StockServiceApplication.java
+++ b/src/main/java/com/nayoon/stock_service/StockServiceApplication.java
@@ -2,8 +2,14 @@ package com.nayoon.stock_service;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EnableFeignClients
+@EnableCaching
 public class StockServiceApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/nayoon/stock_service/client/PurchaseClient.java
+++ b/src/main/java/com/nayoon/stock_service/client/PurchaseClient.java
@@ -1,0 +1,17 @@
+package com.nayoon.stock_service.client;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@FeignClient(name = "purchaseClient", url = "${feign.purchaseClient.url}")
+public interface PurchaseClient {
+
+  /**
+   * 결제 프로세스 진입한 주문 조회
+   */
+  @RequestMapping(method = RequestMethod.GET, value = "/api/v1/internal/purchases/{productId}/quantity", consumes = "application/json")
+  Integer getQuantitySumByProductId(@PathVariable("productId") Long productId);
+
+}

--- a/src/main/java/com/nayoon/stock_service/common/config/RedisConfig.java
+++ b/src/main/java/com/nayoon/stock_service/common/config/RedisConfig.java
@@ -1,0 +1,34 @@
+package com.nayoon.stock_service.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+  @Value("${spring.data.redis.host}")
+  private String redisHost;
+
+  @Value("${spring.data.redis.port}")
+  private int redisPort;
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(new RedisStandaloneConfiguration(redisHost, redisPort));
+  }
+
+  @Bean
+  public RedisTemplate<?, ?> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+    RedisTemplate<?, ?> template = new RedisTemplate<>();
+    template.setConnectionFactory(redisConnectionFactory);
+    template.setKeySerializer(new StringRedisSerializer());
+    return template;
+  }
+
+}

--- a/src/main/java/com/nayoon/stock_service/common/config/SecurityConfig.java
+++ b/src/main/java/com/nayoon/stock_service/common/config/SecurityConfig.java
@@ -1,0 +1,32 @@
+package com.nayoon.stock_service.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer.FrameOptionsConfig;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+  @Bean
+  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    http
+        .csrf(AbstractHttpConfigurer::disable) // csrf 보안 사용 X
+        .formLogin(AbstractHttpConfigurer::disable) // formLogin 사용 X
+        .sessionManagement(AbstractHttpConfigurer::disable) // session 사용 X
+        .headers(h -> h
+            .frameOptions(FrameOptionsConfig::disable)
+        )
+        .httpBasic(AbstractHttpConfigurer::disable)
+    ;
+
+    return http.build();
+  }
+
+}

--- a/src/main/java/com/nayoon/stock_service/common/exception/CustomException.java
+++ b/src/main/java/com/nayoon/stock_service/common/exception/CustomException.java
@@ -1,0 +1,17 @@
+package com.nayoon.stock_service.common.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+    private final String message;
+    private final HttpStatus status;
+
+    public CustomException(ErrorCode errorCode) {
+        this.errorCode = errorCode;
+        this.message = errorCode.getMessage();
+        this.status = errorCode.getStatus();
+    }
+}

--- a/src/main/java/com/nayoon/stock_service/common/exception/ErrorCode.java
+++ b/src/main/java/com/nayoon/stock_service/common/exception/ErrorCode.java
@@ -1,0 +1,36 @@
+package com.nayoon.stock_service.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+  // ------ 4xx ------
+  NOT_FOUND(HttpStatus.BAD_REQUEST, "요청사항을 찾지 못했습니다."),
+  INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+  STOCK_NOT_FOUND(HttpStatus.BAD_REQUEST, "재고 정보가 없습니다."),
+  LIMIT_OF_STOCK(HttpStatus.BAD_REQUEST, "현재 재고가 초기 재고 한도를 초과할 수 없습니다."),
+  OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "주문하려는 상품의 재고가 모두 소진되었습니다."),
+  INVALID_NEW_STOCK(HttpStatus.BAD_REQUEST, "이미 소진된 재고보다 초기 재고를 작게 설정할 수 없습니다."),
+
+  // ------ 5xx ------
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 문제가 발생했습니다."),
+  ;
+
+  private final HttpStatus status;
+  private final String message;
+
+  ErrorCode(final HttpStatus status, String message) {
+    this.status = status;
+    this.message = message;
+  }
+
+  public HttpStatus getStatus() {
+    return status;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+}

--- a/src/main/java/com/nayoon/stock_service/common/exception/ErrorResponse.java
+++ b/src/main/java/com/nayoon/stock_service/common/exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package com.nayoon.stock_service.common.exception;
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.annotation.JsonNaming;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+public class ErrorResponse {
+    private ErrorCode errorCode;
+    private String message;
+}

--- a/src/main/java/com/nayoon/stock_service/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nayoon/stock_service/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,67 @@
+package com.nayoon.stock_service.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ErrorResponse> handleCustomException(CustomException e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .errorCode(e.getErrorCode())
+                .message(e.getMessage())
+                .build();
+
+        log.warn("{}", e.getMessage());
+        return ResponseEntity.status(e.getStatus()).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .errorCode(ErrorCode.INTERNAL_SERVER_ERROR)
+                .message(ErrorCode.INTERNAL_SERVER_ERROR.getMessage())
+                .build();
+
+        log.error("Exception is occurred.", e);
+        return ResponseEntity.status(response.getErrorCode().getStatus()).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        BindingResult bindingResult = e.getBindingResult();
+        StringBuilder errorMessage = new StringBuilder();
+
+        for (FieldError fieldError : bindingResult.getFieldErrors()) {
+            errorMessage.append(fieldError.getDefaultMessage()).append("; ");
+        }
+
+        ErrorResponse response = ErrorResponse.builder()
+                .errorCode(ErrorCode.INVALID_REQUEST)
+                .message(errorMessage.toString())
+                .build();
+
+        log.error("MethodArgumentNotValidException is occurred.", e);
+        return ResponseEntity.status(response.getErrorCode().getStatus()).body(response);
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<ErrorResponse> handleDataIntegrityViolationException(DataIntegrityViolationException e) {
+        ErrorResponse response = ErrorResponse.builder()
+                .errorCode(ErrorCode.INVALID_REQUEST)
+                .message(ErrorCode.INVALID_REQUEST.getMessage())
+                .build();
+
+        log.error("DataIntegrityViolationException is occurred.", e);
+        return ResponseEntity.status(response.getErrorCode().getStatus()).body(response);
+    }
+
+}

--- a/src/main/java/com/nayoon/stock_service/controller/InternalStockController.java
+++ b/src/main/java/com/nayoon/stock_service/controller/InternalStockController.java
@@ -1,0 +1,66 @@
+package com.nayoon.stock_service.controller;
+
+import com.nayoon.stock_service.service.StockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/internal/stocks")
+public class InternalStockController {
+
+  private final StockService stockService;
+
+  /**
+   * 상품 재고 생성 및 업데이트
+   */
+  @PostMapping
+  public ResponseEntity<Void> createOrUpdate(
+      @RequestParam(name = "id") Long productId,
+      @RequestParam(name = "stock") Integer stock
+  ) {
+    stockService.createOrUpdate(productId, stock);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 상품 재고 증가
+   */
+  @PostMapping("/increase")
+  public ResponseEntity<Void> increaseProductStock(
+      @RequestParam(name = "id") Long productId,
+      @RequestParam(name = "quantity") Integer quantity
+  ) {
+    stockService.increaseStock(productId, quantity);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 상품 재고 감소
+   */
+  @PostMapping("/decrease")
+  public ResponseEntity<Void> decreaseProductStock(
+      @RequestParam(name = "id") Long productId,
+      @RequestParam(name = "quantity") Integer quantity
+  ) {
+    stockService.decreaseStock(productId, quantity);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 상품 재고 조회
+   */
+  @GetMapping("/{productId}")
+  public ResponseEntity<Integer> findStock(
+      @PathVariable(name = "productId") Long productId
+  ) {
+    return ResponseEntity.ok().body(stockService.getStock(productId));
+  }
+
+}

--- a/src/main/java/com/nayoon/stock_service/controller/StockController.java
+++ b/src/main/java/com/nayoon/stock_service/controller/StockController.java
@@ -1,0 +1,30 @@
+package com.nayoon.stock_service.controller;
+
+import com.nayoon.stock_service.controller.dto.StockResponseDto;
+import com.nayoon.stock_service.service.StockService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/stocks")
+public class StockController {
+
+  private final StockService stockService;
+
+  /**
+   * 상품 재고 조회
+   */
+  @GetMapping("/{productId}")
+  public ResponseEntity<StockResponseDto> getStock(
+      @PathVariable(name = "productId") Long productId
+  ) {
+    StockResponseDto response = StockResponseDto.valueToDto(stockService.getStock(productId));
+    return ResponseEntity.ok().body(response);
+  }
+
+}

--- a/src/main/java/com/nayoon/stock_service/controller/dto/StockResponseDto.java
+++ b/src/main/java/com/nayoon/stock_service/controller/dto/StockResponseDto.java
@@ -1,0 +1,11 @@
+package com.nayoon.stock_service.controller.dto;
+
+public record StockResponseDto(
+    Integer stock
+) {
+
+  public static StockResponseDto valueToDto(Integer stock) {
+    return new StockResponseDto(stock);
+  }
+
+}

--- a/src/main/java/com/nayoon/stock_service/entity/Stock.java
+++ b/src/main/java/com/nayoon/stock_service/entity/Stock.java
@@ -1,0 +1,57 @@
+package com.nayoon.stock_service.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "stock")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Stock {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "stock_id")
+  private Long id;
+
+  @Column(name = "product_id", updatable = false)
+  private Long productId;
+
+  @Column(name = "stock", nullable = false)
+  private Integer stock;
+
+  @Column(name = "initial_stock", nullable = false)
+  private Integer initialStock;
+
+  @Builder
+  public Stock(Long productId, Integer stock, Integer initialStock) {
+    this.productId = productId;
+    this.stock = stock;
+    this.initialStock = initialStock;
+  }
+
+  public void increase(Integer orderQuantity) {
+    this.stock += orderQuantity;
+  }
+
+  public void decrease(Integer orderQuantity) {
+    this.stock -= orderQuantity;
+  }
+
+  public void updateInitialStock(Integer initialStock) {
+    this.initialStock = initialStock;
+  }
+
+  public void updateStock(Integer stock) {
+    this.stock = stock;
+  }
+
+}

--- a/src/main/java/com/nayoon/stock_service/repository/StockRepository.java
+++ b/src/main/java/com/nayoon/stock_service/repository/StockRepository.java
@@ -1,0 +1,15 @@
+package com.nayoon.stock_service.repository;
+
+import com.nayoon.stock_service.entity.Stock;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockRepository extends JpaRepository<Stock, Long> {
+
+  Optional<Stock> findByProductId(Long productId);
+
+  boolean existsByProductId(Long productId);
+
+  void deleteByProductId(Long productId);
+
+}

--- a/src/main/java/com/nayoon/stock_service/service/StockService.java
+++ b/src/main/java/com/nayoon/stock_service/service/StockService.java
@@ -1,0 +1,100 @@
+package com.nayoon.stock_service.service;
+
+import com.nayoon.stock_service.client.PurchaseClient;
+import com.nayoon.stock_service.common.exception.CustomException;
+import com.nayoon.stock_service.common.exception.ErrorCode;
+import com.nayoon.stock_service.entity.Stock;
+import com.nayoon.stock_service.repository.StockRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CachePut;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class StockService {
+
+  private final StockRepository stockRepository;
+  private final PurchaseClient purchaseClient;
+
+  @Transactional
+  @CachePut(value = "stock", key = "#productId")
+  public Integer createOrUpdate(Long productId, Integer newStock) {
+    boolean exists = stockRepository.existsByProductId(productId);
+
+    if (exists) {
+      return update(productId, newStock);
+    } else {
+      Stock stock = Stock.builder()
+          .productId(productId)
+          .stock(newStock)
+          .initialStock(newStock)
+          .build();
+      stockRepository.save(stock);
+      return stock.getStock();
+    }
+  }
+
+  private Integer update(Long productId, Integer newStock) {
+    Stock stock = loadStock(productId);
+
+    stock.updateInitialStock(newStock);
+    stock.updateStock(calculateStock(productId, newStock));
+
+    stockRepository.save(stock);
+    return stock.getStock();
+  }
+
+  @Transactional
+  @CachePut(value = "stock", key = "#productId")
+  public Integer increaseStock(Long productId, Integer quantity) {
+    Stock stock = loadStock(productId);
+    stock.increase(quantity);
+
+    if (stock.getInitialStock() < stock.getStock()) {
+      throw new CustomException(ErrorCode.LIMIT_OF_STOCK);
+    }
+
+    stockRepository.save(stock);
+    return stock.getStock();
+  }
+
+  @Transactional
+  @CachePut(value = "stock", key = "#productId")
+  public Integer decreaseStock(Long productId, Integer quantity) {
+    Stock stock = loadStock(productId);
+    stock.decrease(quantity);
+
+    if (stock.getInitialStock() < stock.getStock()) {
+      throw new CustomException(ErrorCode.OUT_OF_STOCK);
+    }
+
+    stockRepository.save(stock);
+    return stock.getStock();
+  }
+
+  private Stock loadStock(Long productId) {
+    return stockRepository.findByProductId(productId)
+        .orElseThrow(() -> new CustomException(ErrorCode.STOCK_NOT_FOUND));
+  }
+
+  @Transactional(readOnly = true)
+  @Cacheable(value = "stock", key = "#productId")
+  public Integer getStock(Long productId) {
+    Stock stock = loadStock(productId);
+    return stock.getStock();
+  }
+
+  private Integer calculateStock(Long productId, Integer newStock) {
+    // purchase_service에 결제 프로세스 진입한 주문들의 quantity 합 요청
+    Integer quantitySum = purchaseClient.getQuantitySumByProductId(productId);
+
+    if (newStock < quantitySum) {
+      throw new CustomException(ErrorCode.INVALID_NEW_STOCK);
+    }
+
+    return newStock - quantitySum;
+  }
+
+}

--- a/src/main/java/com/nayoon/stock_service/service/StockService.java
+++ b/src/main/java/com/nayoon/stock_service/service/StockService.java
@@ -64,11 +64,12 @@ public class StockService {
   @CachePut(value = "stock", key = "#productId")
   public Integer decreaseStock(Long productId, Integer quantity) {
     Stock stock = loadStock(productId);
-    stock.decrease(quantity);
 
-    if (stock.getInitialStock() < stock.getStock()) {
+    if (stock.getStock() < quantity) {
       throw new CustomException(ErrorCode.OUT_OF_STOCK);
     }
+
+    stock.decrease(quantity);
 
     stockRepository.save(stock);
     return stock.getStock();

--- a/src/test/java/com/nayoon/stock_service/service/StockServiceTest.java
+++ b/src/test/java/com/nayoon/stock_service/service/StockServiceTest.java
@@ -1,0 +1,241 @@
+package com.nayoon.stock_service.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.nayoon.stock_service.client.PurchaseClient;
+import com.nayoon.stock_service.common.exception.CustomException;
+import com.nayoon.stock_service.common.exception.ErrorCode;
+import com.nayoon.stock_service.entity.Stock;
+import com.nayoon.stock_service.repository.StockRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StockServiceTest {
+
+  @InjectMocks
+  private StockService stockService;
+
+  @Mock
+  private StockRepository stockRepository;
+
+  @Mock
+  private PurchaseClient purchaseClient;
+
+  @Nested
+  @DisplayName("재고 생성")
+  class create {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      Long productId = 1L;
+      Integer initialStock = 100;
+      Integer remainingStock = 0;
+
+      Stock stock = mockStock(productId, remainingStock, initialStock);
+
+      when(stockRepository.existsByProductId(productId)).thenReturn(false);
+      when(stockRepository.save(any())).thenReturn(stock);
+
+      //when
+      Integer result = stockService.createOrUpdate(productId, initialStock);
+
+      //then
+      verify(stockRepository, times(1)).existsByProductId(productId);
+      verify(stockRepository, times(1)).save(any());
+      assertEquals(initialStock, result);
+    }
+
+  }
+
+  @Nested
+  @DisplayName("재고 업데이트")
+  class update {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      Long productId = 1L;
+      Integer oldStock = 300;
+      Integer newStock = 100;
+      Integer remainingStock = 0;
+
+      Stock existingStock = mockStock(productId, remainingStock, oldStock);
+      Stock stock = mockStock(productId, remainingStock, newStock);
+
+      when(stockRepository.existsByProductId(productId)).thenReturn(true);
+      when(stockRepository.findByProductId(productId)).thenReturn(
+          Optional.ofNullable(existingStock));
+      when(stockRepository.save(any())).thenReturn(stock);
+      when(purchaseClient.getQuantitySumByProductId(productId)).thenReturn(10);
+
+      //when
+      Integer result = stockService.createOrUpdate(productId, newStock);
+
+      //then
+      verify(stockRepository, times(1)).findByProductId(productId);
+      verify(stockRepository, times(1)).existsByProductId(productId);
+      verify(stockRepository, times(1)).save(any());
+      assertEquals(newStock - 10, result); // 결제 프로세스 진입한 quantity 합 빼기
+    }
+
+    @Test
+    @DisplayName("실패: 재고 정보 찾을 수 없음")
+    void stockNotFound() {
+      //given
+      Long productId = 1L;
+      Integer newStock = 100;
+
+      when(stockRepository.existsByProductId(productId)).thenReturn(true);
+      //when
+      CustomException exception = assertThrows(CustomException.class, ()
+          -> stockService.createOrUpdate(productId, newStock));
+
+      //then
+      assertEquals(ErrorCode.STOCK_NOT_FOUND, exception.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("실패: 결제 프로세스의 합보다 재고가 작을 수 없음")
+    void invalidNewStock() {
+      //given
+      Long productId = 1L;
+      Integer oldStock = 300;
+      Integer newStock = 5;
+      Integer remainingStock = 0;
+      Stock existingStock = mockStock(productId, remainingStock, oldStock);
+
+      when(stockRepository.existsByProductId(productId)).thenReturn(true);
+      when(stockRepository.findByProductId(productId)).thenReturn(
+          Optional.ofNullable(existingStock));
+      when(purchaseClient.getQuantitySumByProductId(productId)).thenReturn(10);
+
+      //when
+      CustomException exception = assertThrows(CustomException.class, ()
+          -> stockService.createOrUpdate(productId, newStock));
+
+      //then
+      assertEquals(ErrorCode.INVALID_NEW_STOCK, exception.getErrorCode());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("남은 재고 증가")
+  class increaseStock {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      Long productId = 1L;
+      Integer quantity = 5;
+      Integer remainingStock = 0;
+      Integer initialStock = 10;
+      Stock stock = mockStock(productId, remainingStock, initialStock);
+
+      when(stockRepository.findByProductId(productId)).thenReturn(
+          Optional.ofNullable(stock));
+
+      //when
+      Integer result = stockService.increaseStock(productId, quantity);
+
+      //then
+      verify(stockRepository, times(1)).findByProductId(productId);
+      assertEquals(quantity, result);
+    }
+
+    @Test
+    @DisplayName("실패: 남은 재고가 초기 재고보다 클 수 없음")
+    void limitOfStock() {
+      //given
+      Long productId = 1L;
+      Integer quantity = 5;
+      Integer remainingStock = 0;
+      Integer initialStock = 1;
+      Stock stock = mockStock(productId, remainingStock, initialStock);
+
+      when(stockRepository.findByProductId(productId)).thenReturn(
+          Optional.ofNullable(stock));
+
+      //when
+      CustomException exception = assertThrows(CustomException.class, ()
+          -> stockService.increaseStock(productId, quantity));
+
+      //then
+      assertEquals(ErrorCode.LIMIT_OF_STOCK, exception.getErrorCode());
+    }
+
+  }
+
+  @Nested
+  @DisplayName("남은 재고 감소")
+  class decreaseStock {
+
+    @Test
+    @DisplayName("성공")
+    void success() {
+      //given
+      Long productId = 1L;
+      Integer quantity = 5;
+      Integer remainingStock = 5;
+      Integer initialStock = 10;
+      Stock stock = mockStock(productId, remainingStock, initialStock);
+
+      when(stockRepository.findByProductId(productId)).thenReturn(
+          Optional.ofNullable(stock));
+
+      //when
+      Integer result = stockService.decreaseStock(productId, quantity);
+
+      //then
+      verify(stockRepository, times(1)).findByProductId(productId);
+      assertEquals(remainingStock - quantity, result);
+    }
+
+    @Test
+    @DisplayName("실패: 주문할 수 있는 재고가 없음")
+    void outOfStock() {
+      //given
+      Long productId = 1L;
+      Integer quantity = 5;
+      Integer remainingStock = 0;
+      Integer initialStock = 10;
+      Stock stock = mockStock(productId, remainingStock, initialStock);
+
+      when(stockRepository.findByProductId(productId)).thenReturn(
+          Optional.ofNullable(stock));
+
+      //when
+      CustomException exception = assertThrows(CustomException.class, ()
+          -> stockService.decreaseStock(productId, quantity));
+
+      //then
+      assertEquals(ErrorCode.OUT_OF_STOCK, exception.getErrorCode());
+    }
+
+  }
+
+  private Stock mockStock(Long productId, Integer stock, Integer initialStock) {
+    return Stock.builder()
+        .productId(productId)
+        .stock(stock)
+        .initialStock(initialStock)
+        .build();
+  }
+
+}


### PR DESCRIPTION
### 이슈 번호
#1 

### PR 유형
- [x] 신규 기능

### 변경사항
- product_service, purchase_service, payment_service와 내부 통신 구현
  - product_service에 상품 재고 정보 요청
  - purchase_service & payment_service 에서 결제 프로세스 진입 & 이탈시에 stock_service 호출
  - product_service에서 초기 재고 수정 및 상품 삭제 시 stock_service 호출
- 서비스 로직 구현
  - redis 연결
  - 현재 재고 계산 후 redis 업데이트
    - 현재 재고 = 상품 재고 정보 - 결제 진입한 주문
  - 판매자가 초기 재고 변경시 현재 재고 다시 계산하여 업데이트

### 테스트
- [x] 단위 테스트
- [ ] 통합 테스트

### ETC